### PR TITLE
Event testing

### DIFF
--- a/client/components/WaveformPlayer.jsx
+++ b/client/components/WaveformPlayer.jsx
@@ -23,8 +23,11 @@ class WaveformPlayer extends React.Component {
 
 
   componentDidMount() {
-    const songId = Math.floor(Math.random() * 100) + 1;
-    axios.get(`http://localhost:3003/song/${songId}`)
+    let songId = window.location.pathname.split('/')[2];
+    if (parseInt(songId) > 100 || songId === undefined) {
+      songId = 1;
+    }
+    axios.get(`http://localhost:3003/api/${songId}`)
       .then(({ data }) => {
         this.setState({
           song: data.allData.songData,

--- a/client/components/WaveformPlayer.jsx
+++ b/client/components/WaveformPlayer.jsx
@@ -63,7 +63,7 @@ class WaveformPlayer extends React.Component {
     const style = {
       backgroundImage: `linear-gradient(135deg,grey,${song.backgroundColor})`,
     };
-    
+
     return (
       <div className={showModal ? 'wp-greyout' : null}>
         <div className="waveform-player-wrapper" style={style} onClick={this.playPause}>

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -10,6 +10,7 @@ const Comment = require('./playerContainerComponents/Comment.jsx');
 const Artist = require('./titleContainerComponents/Artist.jsx');
 const Playbutton = require('./titleContainerComponents/Playbutton.jsx');
 const Title = require('./titleContainerComponents/Title.jsx');
+const Modal = require('./Modal.jsx');
 
 module.exports = {
   WaveformPlayer,
@@ -24,4 +25,5 @@ module.exports = {
   Artist,
   Playbutton,
   Title,
+  Modal,
 };

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 	</header>
 	<body>
     <div id='app'></div>
+    <div id='modal'></div>
 		<script src='dist/bundle.js'></script>
 	</body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -222,3 +222,53 @@
   font: 12px/1.4 "Lucida Grande","Lucida Sans Unicode","Lucida Sans",Garuda,Verdana,Tahoma,sans-serif;
   margin-left: 10px;
 }
+
+.wp-modal-tint {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(242,242,242,.9);;
+  z-index: 6;
+}
+
+.wp-greyout {
+  height: 100%;
+  width: 100%;
+  filter: grayscale(85%);
+}
+
+.wp-modal {
+  width: 550px;
+  height: 605px;
+  background-color: white;
+  text-align: center;
+  z-index: 7;
+}
+
+.wp-modal-header {
+  position: relative;
+  top: 23px;
+  left: 23px;
+  text-align: left;
+  width: 500px;
+  font-size: 22px;
+  line-height: 1;
+  font-family: "Interstate","Lucida Grande","Lucida Sans Unicode","Lucida Sans",Garuda,Verdana,Tahoma,sans-serif;
+  font-weight: 400;
+  border-bottom: 1px solid #f2f2f2;
+  padding-bottom: 9px;;
+}
+
+.img-modal {
+  position: relative;
+  top: 46px;
+}
+
+hr .modal {
+  width: 500px;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -4,13 +4,10 @@ const db = require('../database/index.js');
 
 const app = express();
 
-app.use('/', express.static(path.join(__dirname, 'public')));
 app.use('/', express.static('public'));
-app.get('/', (req, res) => {
-  res.send('This is the server response');
-});
+app.use('/song/:id', express.static('public'));
 
-app.get('/song/:id', (req, res) => {
+app.get('/api/:id', (req, res) => {
   db.getSongData(req.params.id, res.send.bind(res));
 });
 

--- a/test/modal.test.js
+++ b/test/modal.test.js
@@ -1,0 +1,33 @@
+const React = require('react');
+const ReactDom = require('react-dom');
+const Enzyme = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+const { song, comments } = require('./mockData.js');
+const Modules = require('../client/components');
+const sinon = require('sinon');
+
+const { shallow } = Enzyme;
+Enzyme.configure({ adapter: new Adapter() });
+
+describe(' <Modal /> ', () => {
+
+  const modal = global.document.createElement('div');
+  modal.setAttribute('id', 'modal');
+  const body = global.document.querySelector('body');
+  body.appendChild(modal);
+
+  test('should render proper image', () => {
+    const wrapper = shallow(<Modules.Modal song={song} toggleModal={() => null} />);
+    const modalImage = wrapper.find('.img-modal').props().src;
+    expect(modalImage).toBe(song.coverArt);
+  });
+
+  test('should call toggleModal onClick', () => {
+    const spy = sinon.spy();
+
+    const wrapper = shallow(<Modules.Modal song={song} toggleModal={spy} />);
+    wrapper.find('.wp-modal-tint').simulate('click');
+    expect(spy.called).toBe(true);
+  });
+  
+});

--- a/test/playerContainer.test.js
+++ b/test/playerContainer.test.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactTestUtils = require('react-dom/test-utils');
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const sinon = require('sinon');
@@ -13,5 +14,22 @@ describe(' <PlayerContainer /> ', () => {
     const wrapper = shallow(<Modules.PlayerContainer song={song} comments={comments} />);
     const { waveform } = (wrapper.find(Modules.Waveform).props());
     expect(waveform.slice(-4)).toBe('.png');
+  });
+  test('comments should not be immediately visible', () => {
+    const wrapper = shallow(<Modules.Comment comment={comments[0]} />);
+    const children = wrapper.find('.wp-comment-wrapper');
+    expect(children.length).toBe(1);
+  })
+
+  test('avatar should show/hide comments on mouseEnter/mouseLeave', () => {
+    const wrapper = shallow(<Modules.Comment comment={comments[0]} />);
+
+    expect(wrapper.find('.wp-comment').children().length).toBe(0);
+
+    wrapper.find('.wp-comment-avatar').simulate('mouseEnter');
+    expect(wrapper.find('.wp-comment').children().length).toBe(2);
+
+    wrapper.find('.wp-comment-avatar').simulate('mouseLeave');
+    expect(wrapper.find('.wp-comment').children().length).toBe(0);
   });
 });

--- a/test/titleContainer.test.js
+++ b/test/titleContainer.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const { song, comments } = require('./mockData.js');
 const Modules = require('../client/components');
 
-const { shallow } = Enzyme;
+const { shallow, mount } = Enzyme;
 Enzyme.configure({ adapter: new Adapter() });
 
 describe(' <TitleContainer /> ', () => {
@@ -13,4 +13,18 @@ describe(' <TitleContainer /> ', () => {
     const wrapper = shallow(<Modules.TitleContainer song={song} />);
     expect(wrapper.find('div.title-container').children()).toHaveLength(3);
   });
+
+  test('should change playbutton graphic if playing', () => {
+    const wrapper1 = mount(<Modules.Playbutton isPlaying={false} playPause={() => null} />);
+    const wrapper2 = mount(<Modules.Playbutton isPlaying={true} playPause={() => null} />);
+
+
+    expect(wrapper1.containsMatchingElement(<div className="wp-play" />)).toBe(true);
+    expect(wrapper1.containsMatchingElement(<div className="wp-pause1"/>)).toBe(false);
+
+    expect(wrapper2.containsMatchingElement(<div className="wp-play" />)).toBe(false);
+    expect(wrapper2.containsMatchingElement(<div className="wp-pause2"/>)).toBe(true);
+  });
+
+
 });

--- a/test/waveformPlayer.test.js
+++ b/test/waveformPlayer.test.js
@@ -8,7 +8,7 @@ const { shallow } = Enzyme;
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('<WaveformPlayer />', () => {
-  test('Should pass down correct props to children components', async () => {
+  test('should pass down correct props to children components', async () => {
     const wrapper = shallow(<Modules.WaveformPlayer />);
     await wrapper.setState({ song, comments });
 
@@ -22,4 +22,25 @@ describe('<WaveformPlayer />', () => {
     expect(infoContainer.props().song).toBe(song);
     expect(playerContainer.props().comments).toBe(comments);
   });
+
+  test('should show modal when showModal is set to true', () => {
+    const wrapper = shallow(<Modules.WaveformPlayer />);
+    const children = wrapper.find('.waveform-player-wrapper').children().length;
+    wrapper.setState({ showModal: true});
+    const childrenWithModal = wrapper.find('.waveform-player-wrapper').children().length;
+    expect(childrenWithModal).toBe(children + 1);
+  });
+
+  test('should change state to playing if clicked', () => {
+    const wrapper = shallow(<Modules.WaveformPlayer />);
+    wrapper.find('.waveform-player-wrapper').simulate('click', { currentTarget: 'x', target: 'x' });
+    expect(wrapper.state().isPlaying).toBe(true);
+  });
+  
+  test('should change state when toggleModal is invoked', () => {
+    const wrapper = shallow(<Modules.WaveformPlayer />);
+    wrapper.instance().toggleModal({ currentTarget: 'x', target: 'x' });
+    expect(wrapper.state().showModal).toBe(true);
+  });
+
 });


### PR DESCRIPTION
Wrote further tests to accommodate recent changes to the view, in terms of extra components and component interactivity. 

There's also a small adjustment made to the server such that a call to localhost:3003/song/:id returns the page for specific songs with id's between 1 and 100.

Here's the specs on coverage: 

<img width="837" alt="screen shot 2018-09-15 at 9 54 44 pm" src="https://user-images.githubusercontent.com/40322163/45593056-0cdb4480-b932-11e8-8c66-fb56e0a6c91c.png">
